### PR TITLE
added new sms provider SmsPubli

### DIFF
--- a/src/Utils/HttpClient.php
+++ b/src/Utils/HttpClient.php
@@ -15,7 +15,8 @@ class HttpClient
     const OPTIONS = 'OPTIONS';
 
 
-    public static function request($method, $url, $urlParams = [], $headers = [], $options = [], $data = [])
+    public static function request(string $method, string $url, object|array $urlParams = [],
+                                   array $headers = [], array $options = [], mixed $data = [])
     {
         if (!empty($urlParams)) {
             $url .= '?'.http_build_query($urlParams);
@@ -25,20 +26,15 @@ class HttpClient
             $options = ['timeout' => 10, "connect_timeout"  => 10, 'verify' => false];
         }
 
-        try {
-            $response = null;
-            $response = match ($method) {
-                self::GET => Requests::get($url, $headers, $options),
-                self::PUT => Requests::put($url, $headers, $data, $options),
-                self::POST => Requests::post($url, $headers, $data, $options),
-                self::PATCH => Requests::patch($url, $headers, $data, $options),
-                self::DELETE => Requests::delete($url, $headers, $options),
-                self::HEAD => Requests::head($url, $headers, $options),
-                self::OPTIONS => Requests::options($url, $headers, $data, $options),
-            };
-        } catch (Requests_Exception $e) {
-            $response = null;
-        }
+        $response = match ($method) {
+            self::GET => Requests::get($url, $headers, $options),
+            self::PUT => Requests::put($url, $headers, $data, $options),
+            self::POST => Requests::post($url, $headers, $data, $options),
+            self::PATCH => Requests::patch($url, $headers, $data, $options),
+            self::DELETE => Requests::delete($url, $headers, $options),
+            self::HEAD => Requests::head($url, $headers, $options),
+            self::OPTIONS => Requests::options($url, $headers, $data, $options),
+        };
 
         return (object)[
             'code' => $response !== null ? $response->status_code : 404,

--- a/src/Utils/NosRESTGateway.php
+++ b/src/Utils/NosRESTGateway.php
@@ -44,7 +44,7 @@ class NosRESTGateway
             ],
         ];
 
-        $response = @file_get_contents($url, false, stream_context_create($arrContextOptions));
+        $response = file_get_contents($url, false, stream_context_create($arrContextOptions));
 
         if ($response === false) {
             $this->error = "SMS send failed: got empty response";

--- a/src/Utils/SmsPubli.php
+++ b/src/Utils/SmsPubli.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Servdebt\SlimCore\Utils;
+
+class SmsPubli
+{
+    public string $apiKey;
+    public string $username;
+    public string $senderName;
+    public string $reportUrl;
+
+    public function __construct($apiKey, $username = null)
+    {
+        $this->apiKey = $apiKey;
+        $this->username = $username;
+    }
+
+    public function setFrom($name): self
+    {
+        $this->senderName = $name;
+
+        return $this;
+    }
+
+    public function setReportUrl($url): self
+    {
+        $this->reportUrl = $url;
+
+        return $this;
+    }
+
+    public function sendSms($countryCode, $destination, $message, $sendAt = null) :mixed
+    {
+        $data = json_encode([
+            "api_key" => $this->apiKey,
+            "user_name" => $this->username,
+            "report_url" => $this->reportUrl,
+            "concat" => 1,
+            "messages" => [
+                [
+                    "from"    => $this->senderName,
+                    "to"      => $countryCode.$destination,
+                    "text"    => $message,
+                    "send_at" => $sendAt ?? date("Y-m-d H:i:s"),
+                ]
+            ]
+        ]);
+
+        $res = HttpClient::request(HttpClient::POST,
+            "https://api.gateway360.com/api/3.0/sms/send",
+            [],
+            ['Content-Type' => 'application/json'],
+            [],
+            $data
+        );
+
+        return (object)['code' => $res->code, 'body' => json_decode($res->body)];
+    }
+
+}


### PR DESCRIPTION
Send sms with SmsPubli example:
````
$res = (new \Servdebt\SlimCore\Utils\SmsPubli('apikey', 'username'))
            ->setFrom('SERVDEBT')
            ->setReportUrl("https://servdebt.com/smsreport")
            ->sendSms('00351', '961234567', "test 1234567890");

        echo $res->code .PHP_EOL;
        echo ($res->body->result[0]->status ?? null) .PHP_EOL;
        echo ($res->body->result[0]->sms_id ?? null) .PHP_EOL;